### PR TITLE
fix: Add missing soundfile dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pyttsx3
 PyAudio
 llama-cpp-python==0.3.16
 diskcache==5.6.3
+soundfile==0.13.1


### PR DESCRIPTION
This commit adds the `soundfile` library to the `requirements.txt` file.

The `speech_recognition` library's `recognize_whisper` function requires `soundfile` to process audio data, but it was not explicitly listed as a dependency. This caused a `ModuleNotFoundError` when running the application.

This change resolves the error by adding `soundfile` to the list of required packages.